### PR TITLE
fix: remove machine-setup mount

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -79,8 +79,6 @@ spec:
           mountPath: /etc/credentials
         - name: certs
           mountPath: /etc/ssl/certs
-        - name: machine-setup
-          mountPath: /etc/machinesetup
       terminationGracePeriodSeconds: 10
       volumes:
       - name: cert
@@ -93,9 +91,6 @@ spec:
       - name: certs
         hostPath:
           path: /etc/ssl/certs
-      - name: machine-setup
-        configMap:
-          name: machine-setup
 ---
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
We ran into this yesterday when trying to do a cluster-api-provider deployment. This configmap is no longer used