### PR TITLE
fix: don't delete cluster resources if machines exist

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1001,7 +1001,7 @@
   revision = "5e45bb682580c9be5ffa4d27d367f0eeba125c7b"
 
 [[projects]]
-  digest = "1:bc04752ec8a48d212a0db41c2085bb468ae7c8c34bcb317f552b68f4fe34865b"
+  digest = "1:07bf69e67f3e57593c9d9f70be97b11dfb61b53e51cf5c5380437821f6983142"
   name = "sigs.k8s.io/cluster-api"
   packages = [
     "pkg/apis",
@@ -1013,8 +1013,8 @@
     "pkg/util",
   ]
   pruneopts = "T"
-  revision = "29fee0a9ef590af33bbaa167ed17a8be50825679"
-  version = "0.1.0"
+  revision = "0f911c1f65a59b65791a1afb6e66a9503801f59f"
+  version = "0.1.1"
 
 [[projects]]
   digest = "1:5aa50779f75cc439edd3455a6dee7cf179b52f8dde764a47cc929693485d1afb"

--- a/README.md
+++ b/README.md
@@ -5,4 +5,5 @@ A [cluster-api](https://github.com/kubernetes-sigs/cluster-api) provider for dep
 
 #### Getting Started Guides:
 
+- [AWS](docs/AWS.md)
 - [GCE](docs/GCE.md)

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -56,7 +56,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	machineActuator, err := machine.NewMachineActuator(machine.MachineActuatorParams{})
+	machineActuator, err := machine.NewMachineActuator(mgr, machine.MachineActuatorParams{})
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/cloud/talos/actuators/machine/actuator.go
+++ b/pkg/cloud/talos/actuators/machine/actuator.go
@@ -24,6 +24,8 @@ import (
 	"github.com/talos-systems/cluster-api-provider-talos/pkg/cloud/talos/utils"
 	"k8s.io/client-go/kubernetes"
 	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
 const (
@@ -37,22 +39,22 @@ const (
 
 // MachineActuator is responsible for performing machine reconciliation
 type MachineActuator struct {
-	Clientset *kubernetes.Clientset
+	Clientset        *kubernetes.Clientset
+	controllerClient client.Client
 }
 
 // MachineActuatorParams holds parameter information for Actuator
-type MachineActuatorParams struct {
-}
+type MachineActuatorParams struct{}
 
 // NewMachineActuator creates a new Actuator
-func NewMachineActuator(params MachineActuatorParams) (*MachineActuator, error) {
+func NewMachineActuator(mgr manager.Manager, params MachineActuatorParams) (*MachineActuator, error) {
 
 	clientset, err := utils.CreateK8sClientSet()
 	if err != nil {
 		return nil, err
 	}
 
-	return &MachineActuator{Clientset: clientset}, nil
+	return &MachineActuator{Clientset: clientset, controllerClient: mgr.GetClient()}, nil
 }
 
 // Create creates a machine and is invoked by the Machine Controller

--- a/pkg/cloud/talos/provisioners/aws/aws.go
+++ b/pkg/cloud/talos/provisioners/aws/aws.go
@@ -268,7 +268,7 @@ func fetchInstanceID(clusterName string, instanceName string, client *ec2.EC2) (
 		return nil, nil
 	}
 	if len(res.Reservations[0].Instances) > 1 {
-		return nil, errors.New("[AWS] Multiple instanes with same filter info")
+		return nil, errors.New("[AWS] Multiple instances with same filter info")
 	}
 
 	return res.Reservations[0].Instances[0].InstanceId, nil


### PR DESCRIPTION
This PR will close #6. Before deleting a cluster resource, we now take a look at the machine list and filter down by the cluster label. If there are machines that belong to that cluster, we throw an error so that users will be forced to delete the machine resources before carrying out their cluster delete. 