### PR TITLE
fix: send network devices as nil when marhalling yaml

### DIFF
--- a/pkg/cloud/talos/provisioners/packet/packet.go
+++ b/pkg/cloud/talos/provisioners/packet/packet.go
@@ -39,15 +39,15 @@ type Userdata struct {
 	Security   interface{}
 	Services   interface{}
 	Install    map[string]interface{}
-	Networking Network
+	Networking *Network
 }
 
 type Network struct {
-	OS OS
+	OS *OS `yaml:"os,omitempty"`
 }
 
 type OS struct {
-	Devices []map[string]interface{}
+	Devices []map[string]interface{} `yaml:"devices,omitempty"`
 }
 
 //NewPacket returns an instance of the Packet provisioner
@@ -104,6 +104,9 @@ func (packet *Packet) Create(cluster *clusterv1.Cluster, machine *clusterv1.Mach
 		floatingIP = clusterSpec.Masters.IPs[index]
 
 		//Haxx on haxx b/c dhcp value needs to be a bool so the whole networking.os.devices block needs to be a map of interfaces
+		if udStruct.Networking == nil {
+			udStruct.Networking = &Network{OS: &OS{Devices: make([]map[string]interface{}, 0)}}
+		}
 		udStruct.Networking.OS.Devices = append(udStruct.Networking.OS.Devices, map[string]interface{}{"interface": "lo", "cidr": floatingIP + "/32"})
 		udStruct.Networking.OS.Devices = append(udStruct.Networking.OS.Devices, map[string]interface{}{"interface": "eth0", "dhcp": true})
 	}


### PR DESCRIPTION
This PR is necessary to fix a bug where dhcp wasn't getting started on worker nodes. We added omitempty to the network structs that get marshalled up into userdata, which appears to have allowed dhcp to work as expected.

PR will depend on a successful run of conformance tests.