### PR TITLE
feat: add azure provisioner

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -10,6 +10,45 @@
   version = "v0.42.0"
 
 [[projects]]
+  digest = "1:d087148460449bd94a42fb7410f2c8cadca85f5a74d9d08bcdf2e96166247d31"
+  name = "contrib.go.opencensus.io/exporter/ocagent"
+  packages = ["."]
+  pruneopts = "T"
+  revision = "dcb33c7f3b7cfe67e8a2cea10207ede1b7c40764"
+  version = "v0.4.12"
+
+[[projects]]
+  digest = "1:369cee853d4bbe264f2fab84517983cee2f4a0c53ac20786c275d16304d9fc2b"
+  name = "github.com/Azure/azure-sdk-for-go"
+  packages = [
+    "services/compute/mgmt/2019-03-01/compute",
+    "services/network/mgmt/2019-04-01/network",
+    "version",
+  ]
+  pruneopts = "T"
+  revision = "397140cd20ce375b8da0534436fb918389917264"
+  version = "v31.1.0"
+
+[[projects]]
+  digest = "1:4f7898d4695cda7d3a4aa030f2df060ec8a25ba291ddb8fc3491aeffcc1f2dbd"
+  name = "github.com/Azure/go-autorest"
+  packages = [
+    "autorest",
+    "autorest/adal",
+    "autorest/azure",
+    "autorest/azure/auth",
+    "autorest/azure/cli",
+    "autorest/date",
+    "autorest/to",
+    "autorest/validation",
+    "logger",
+    "tracing",
+  ]
+  pruneopts = "T"
+  revision = "2913f263500c4a5b23dada1b46ccd22ac972315f"
+  version = "v12.3.0"
+
+[[projects]]
   digest = "1:464aef731a5f82ded547c62e249a2e9ec59fbbc9ddab53cda7b9857852630a61"
   name = "github.com/appscode/jsonpatch"
   packages = ["."]
@@ -67,6 +106,21 @@
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:ad70cf78ff17abf96d92a6082f4d3241fef8f149118f87c3a267ed47a08be603"
+  name = "github.com/census-instrumentation/opencensus-proto"
+  packages = [
+    "gen-go/agent/common/v1",
+    "gen-go/agent/metrics/v1",
+    "gen-go/agent/trace/v1",
+    "gen-go/metrics/v1",
+    "gen-go/resource/v1",
+    "gen-go/trace/v1",
+  ]
+  pruneopts = "T"
+  revision = "d89fa54de508111353cb0b06403c00569be780d8"
+  version = "v0.2.1"
+
+[[projects]]
   digest = "1:89e3effda4e0decfdeea32b86f329242741cca58606681c5bb1ea89382d0f5e6"
   name = "github.com/containerd/containerd"
   packages = ["defaults"]
@@ -81,6 +135,22 @@
   pruneopts = "T"
   revision = "8991bc29aa16c548c550c7ff78260e27b9ab7c73"
   version = "v1.1.1"
+
+[[projects]]
+  digest = "1:6b014c67cb522566c30ef02116f9acb50cd60954708cf92c6654e2985696db18"
+  name = "github.com/dgrijalva/jwt-go"
+  packages = ["."]
+  pruneopts = "T"
+  revision = "06ea1031745cb8b3dab3f6a236daf2b0aa468b7e"
+  version = "v3.2.0"
+
+[[projects]]
+  digest = "1:cf0d2e435fd4ce45b789e93ef24b5f08e86be0e9807a16beb3694e2d8c9af965"
+  name = "github.com/dimchansky/utfbom"
+  packages = ["."]
+  pruneopts = "T"
+  revision = "d2133a1ce379ef6fa992b0514a77146c60db9d1c"
+  version = "v1.1.0"
 
 [[projects]]
   digest = "1:4c9fb95cf096078841e90a4231b3d2ce8f0a306323ef0e363b4cbdcc2e449aae"
@@ -148,11 +218,18 @@
   digest = "1:ee6b8c03e5ab6cf9628a3c538430d007f8534483dc46c7ff5955a4359d5ef865"
   name = "github.com/golang/protobuf"
   packages = [
+    "jsonpb",
     "proto",
+    "protoc-gen-go/descriptor",
+    "protoc-gen-go/generator",
+    "protoc-gen-go/generator/internal/remap",
+    "protoc-gen-go/plugin",
     "ptypes",
     "ptypes/any",
     "ptypes/duration",
+    "ptypes/struct",
     "ptypes/timestamp",
+    "ptypes/wrappers",
   ]
   pruneopts = "T"
   revision = "6c65a5562fc06764971b7c5d05c76c75e84bdbf7"
@@ -204,6 +281,18 @@
   ]
   pruneopts = "T"
   revision = "901d90724c7919163f472a9812253fb26761123d"
+
+[[projects]]
+  digest = "1:20fdee92b940d438a4b38d7e5eae5e25e390e9480ee6ae756fc6f015b382a345"
+  name = "github.com/grpc-ecosystem/grpc-gateway"
+  packages = [
+    "internal",
+    "runtime",
+    "utilities",
+  ]
+  pruneopts = "T"
+  revision = "ad529a448ba494a88058f9e5be0988713174ac86"
+  version = "v1.9.5"
 
 [[projects]]
   digest = "1:d15ee511aa0f56baacc1eb4c6b922fa1c03b38413b6be18166b996d82a0156ea"
@@ -284,6 +373,14 @@
   pruneopts = "T"
   revision = "c12348ce28de40eed0136aa2b644d0ee0650e56c"
   version = "v1.0.1"
+
+[[projects]]
+  digest = "1:5d231480e1c64a726869bc4142d270184c419749d34f167646baa21008eb0a79"
+  name = "github.com/mitchellh/go-homedir"
+  packages = ["."]
+  pruneopts = "T"
+  revision = "af06845cf3004701891bf4fdb884bfe4920b3727"
+  version = "v1.1.0"
 
 [[projects]]
   digest = "1:33422d238f147d247752996a26574ac48dcf472976eda7f5134015f06bf16563"
@@ -488,7 +585,7 @@
   version = "v0.2.0-alpha.2"
 
 [[projects]]
-  digest = "1:2db3938c92f77a06bcb7eda1fbd3ee4c5f2c059dcb77e4624dd47fabe823d541"
+  digest = "1:b0115d3a61a91feb9163bd91ca59d51fd6d40e2ea081293273263699ecb0c3d3"
   name = "go.opencensus.io"
   packages = [
     ".",
@@ -496,8 +593,10 @@
     "internal/tagencoding",
     "metric/metricdata",
     "metric/metricproducer",
+    "plugin/ocgrpc",
     "plugin/ochttp",
     "plugin/ochttp/propagation/b3",
+    "plugin/ochttp/propagation/tracecontext",
     "resource",
     "stats",
     "stats/internal",
@@ -509,8 +608,8 @@
     "trace/tracestate",
   ]
   pruneopts = "T"
-  revision = "9c377598961b706d1542bd2d84d538b5094d596e"
-  version = "v0.22.0"
+  revision = "43463a80402d8447b7fce0d2c58edf1687ff0b58"
+  version = "v0.19.3"
 
 [[projects]]
   digest = "1:1cb088da2add92b2955ba3f26d959e08e4639f53a50fb6cef36b5bc04b241103"
@@ -547,7 +646,11 @@
   branch = "master"
   digest = "1:e31be034fd6b7057f387bf33683b2a4a2468d299bc311ff45f8dc269a8ea046b"
   name = "golang.org/x/crypto"
-  packages = ["ssh/terminal"]
+  packages = [
+    "pkcs12",
+    "pkcs12/internal/rc2",
+    "ssh/terminal",
+  ]
   pruneopts = "T"
   revision = "4def268fd1a49955bfb3dda92fe3db4f924f2285"
 
@@ -584,6 +687,14 @@
   ]
   pruneopts = "T"
   revision = "0f29369cfe4552d0e4bcddc57cc75f4d7e672a33"
+
+[[projects]]
+  branch = "master"
+  digest = "1:31eb938007354c1ad51e4a5c08c815cd242dbf32bc3a426013a0ce0578eb2e5c"
+  name = "golang.org/x/sync"
+  packages = ["semaphore"]
+  pruneopts = "T"
+  revision = "112230192c580c3556b8cee6403af37a4fc5f28c"
 
 [[projects]]
   branch = "master"
@@ -673,6 +784,7 @@
     "googleapi/transport",
     "internal",
     "option",
+    "support/bundler",
     "transport/http",
     "transport/http/internal/propagation",
   ]
@@ -703,7 +815,11 @@
   branch = "master"
   digest = "1:53a69ca05e2f34d0d6e5cc02d2d3b0c0f815628965757fb5aaf04aa83ca5cc07"
   name = "google.golang.org/genproto"
-  packages = ["googleapis/rpc/status"]
+  packages = [
+    "googleapis/api/httpbody",
+    "googleapis/rpc/status",
+    "protobuf/field_mask",
+  ]
   pruneopts = "T"
   revision = "c506a9f9061087022822e8da603a52fc387115a8"
 
@@ -1162,6 +1278,12 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-03-01/compute",
+    "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-04-01/network",
+    "github.com/Azure/go-autorest/autorest",
+    "github.com/Azure/go-autorest/autorest/azure",
+    "github.com/Azure/go-autorest/autorest/azure/auth",
+    "github.com/Azure/go-autorest/autorest/to",
     "github.com/aws/aws-sdk-go/aws",
     "github.com/aws/aws-sdk-go/aws/session",
     "github.com/aws/aws-sdk-go/service/ec2",

--- a/README.md
+++ b/README.md
@@ -6,5 +6,6 @@ A [cluster-api](https://github.com/kubernetes-sigs/cluster-api) provider for dep
 #### Getting Started Guides:
 
 - [AWS](docs/AWS.md)
-- [Packet](docs/Packet.md)
+- [Azure](docs/Azure.md)
 - [GCE](docs/GCE.md)
+- [Packet](docs/Packet.md)

--- a/config/samples/cluster-deployment/azure/kustomization.yaml
+++ b/config/samples/cluster-deployment/azure/kustomization.yaml
@@ -1,0 +1,39 @@
+bases:
+  - ../base/
+
+patchesJson6902:
+  ##Add master static IPs to cluster.yaml
+  - target:
+      group: cluster.k8s.io
+      version: v1alpha1
+      kind: Cluster
+      name: talos-test-cluster
+    path: master-ips.yaml
+
+  ##Patch each master with gce config
+  - target:
+      group: cluster.k8s.io
+      version: v1alpha1
+      kind: Machine
+      name: talos-test-cluster-master-0
+    path: platform-config-masters.yaml
+  # - target:
+  #     group: cluster.k8s.io
+  #     version: v1alpha1
+  #     kind: Machine
+  #     name: talos-test-cluster-master-1
+  #   path: platform-config-masters.yaml
+  # - target:
+  #     group: cluster.k8s.io
+  #     version: v1alpha1
+  #     kind: Machine
+  #     name: talos-test-cluster-master-2
+  #   path: platform-config-masters.yaml
+
+  ##Patch workers with gce config
+  - target:
+      group: cluster.k8s.io
+      version: v1alpha1
+      kind: MachineDeployment
+      name: talos-test-cluster-workers
+    path: platform-config-workers.yaml

--- a/config/samples/cluster-deployment/azure/master-ips.yaml
+++ b/config/samples/cluster-deployment/azure/master-ips.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/providerSpec/value/masters/ips
+  value: [x.x.x.x, y.y.y.y, z.z.z.z]

--- a/config/samples/cluster-deployment/azure/platform-config-masters.yaml
+++ b/config/samples/cluster-deployment/azure/platform-config-masters.yaml
@@ -1,0 +1,14 @@
+- op: replace
+  path: /spec/providerSpec/value/platform
+  value:
+    config: |-
+      location: "centralus"
+      resourcegroup: "{{RESOURCE_GROUP}}"
+      instances:
+        type:  "Standard_D2_v3"
+        image: "{{IMAGE_RESOURCE_ID}}"
+        network: "{{NETWORK}}"
+        subnet: "{{SUBNET}}"
+        disks:
+          size: 10
+    type: azure

--- a/config/samples/cluster-deployment/azure/platform-config-workers.yaml
+++ b/config/samples/cluster-deployment/azure/platform-config-workers.yaml
@@ -1,0 +1,14 @@
+- op: replace
+  path: /spec/template/spec/providerSpec/value/platform
+  value:
+    config: |-
+      location: "centralus"
+      resourcegroup: "{{RESOURCE_GROUP}}"
+      instances:
+        type:  "Standard_D2_v3"
+        image: "{{IMAGE_RESOURCE_ID}}"
+        network: "{{NETWORK}}"
+        subnet: "{{SUBNET}}"
+        disks:
+          size: 10
+    type: azure

--- a/docs/Azure.md
+++ b/docs/Azure.md
@@ -1,0 +1,50 @@
+# cluster-api-provider-talos on Azure
+
+This guide will detail how to deploy the Talos provider into an existing Kubernetes cluster, as well as how to configure it to create Clusters and Machines in Azure.
+
+#### Prereqs
+
+This guide assumes you have several prereqs created in Azure. These are:
+
+- Resource group
+- Virtual network
+- Subnet in the virtual network
+- A security group for the subnet that allows ports 443, 50000, 50001
+- Public IPs for each master
+- Storage account for image upload
+- The Azure CLI configured and talking to your Azure account
+
+#### Import Image
+
+To import the image, you must download a .tar.gz talos release, add it to Google storage, and import it as an image.
+
+- Download the `talos-azure.tar.gz` image from our [Github releases](https://github.com/talos-systems/talos/releases) and extract it to get `disk.vhd`.
+
+- Follow the [Azure instructions](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/upload-vhd) on importing the vhd to cloud storage and creating an image.
+
+
+#### Prepare bootstrap cluster
+
+In your cluster that you'll be using to create other clusters, you must prepare a few bits.
+
+- Git clone this repo.
+
+- Create a namespace for our provider with `kubectl create ns cluster-api-provider-talos-system`.
+
+- In Azure, create service account keys and write them to a file called `service-account-azure.json` with the command `az ad sp create-for-rbac --sdk-auth > /path/to/service-account-azure.json`.
+
+- Create a secret with the key generated above: `kubectl create secret generic azure-credentials -n cluster-api-provider-talos-system --from-file /path/to/service-account-azure.json`.
+
+- Generate the manifests for deploying into the bootstrap cluster with `make manifests` from the `cluster-api-provider-talos` directory.
+
+- Deploy the generated manifests with `kubectl create -f provider-components.yaml`
+
+#### Create new clusters
+
+There are sample kustomize templates in [config/samples/cluster-deployment/azure](../config/samples/cluster-deployment/azure) for deploying clusters. These will be our starting point.
+
+- Edit `master-ips.yaml`, `platform-config-master.yaml`, and `platform-config-workers.yaml` with your relevant data from the prereqs mentioned above. 
+
+- From `config/samples/cluster-deployment/azure` issue `kustomize build | kubectl apply -f -`.
+
+- The talos config for your master can be found with `kubectl get cm -n cluster-api-provider-talos-system talos-test-cluster-master-0 -o jsonpath='{.data.talosconfig}'`.

--- a/pkg/cloud/talos/actuators/machine/actuator.go
+++ b/pkg/cloud/talos/actuators/machine/actuator.go
@@ -66,7 +66,7 @@ func (a *MachineActuator) Create(ctx context.Context, cluster *clusterv1.Cluster
 		return err
 	}
 
-	err = provisioner.Create(cluster, machine, a.Clientset)
+	err = provisioner.Create(ctx, cluster, machine, a.Clientset)
 	if err != nil {
 		return err
 	}
@@ -83,7 +83,7 @@ func (a *MachineActuator) Delete(ctx context.Context, cluster *clusterv1.Cluster
 		return err
 	}
 
-	err = provisioner.Delete(cluster, machine, a.Clientset)
+	err = provisioner.Delete(ctx, cluster, machine, a.Clientset)
 	if err != nil {
 		return err
 	}
@@ -100,7 +100,7 @@ func (a *MachineActuator) Update(ctx context.Context, cluster *clusterv1.Cluster
 		return err
 	}
 
-	err = provisioner.Update(cluster, machine, a.Clientset)
+	err = provisioner.Update(ctx, cluster, machine, a.Clientset)
 	if err != nil {
 		return err
 	}
@@ -116,7 +116,7 @@ func (a *MachineActuator) Exists(ctx context.Context, cluster *clusterv1.Cluster
 		return true, err
 	}
 
-	exists, err := provisioner.Exists(cluster, machine, a.Clientset)
+	exists, err := provisioner.Exists(ctx, cluster, machine, a.Clientset)
 	if err != nil {
 		return true, err
 	}

--- a/pkg/cloud/talos/provisioners/aws/aws.go
+++ b/pkg/cloud/talos/provisioners/aws/aws.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"context"
 	"encoding/base64"
 	"errors"
 	"log"
@@ -47,7 +48,7 @@ func NewAWS() (*AWS, error) {
 }
 
 // Create creates an instance in AWS.
-func (aws *AWS) Create(cluster *clusterv1.Cluster, machine *clusterv1.Machine, clientset *kubernetes.Clientset) error {
+func (aws *AWS) Create(ctx context.Context, cluster *clusterv1.Cluster, machine *clusterv1.Machine, clientset *kubernetes.Clientset) error {
 
 	// TODO: There's a lot of repition of this machinespec -> ec2client block. Need to see if there's a more DRY way.
 	// Fish out configs and create an ec2 client
@@ -150,12 +151,12 @@ func (aws *AWS) Create(cluster *clusterv1.Cluster, machine *clusterv1.Machine, c
 }
 
 //Update updates a given AWS instance.
-func (aws *AWS) Update(cluster *clusterv1.Cluster, machine *clusterv1.Machine, clientset *kubernetes.Clientset) error {
+func (aws *AWS) Update(ctx context.Context, cluster *clusterv1.Cluster, machine *clusterv1.Machine, clientset *kubernetes.Clientset) error {
 	return nil
 }
 
 // Delete deletes a AWS instance.
-func (aws *AWS) Delete(cluster *clusterv1.Cluster, machine *clusterv1.Machine, clientset *kubernetes.Clientset) error {
+func (aws *AWS) Delete(ctx context.Context, cluster *clusterv1.Cluster, machine *clusterv1.Machine, clientset *kubernetes.Clientset) error {
 
 	// Fish out configs and create an ec2 client
 	machineSpec, err := utils.MachineProviderFromSpec(machine.Spec.ProviderSpec)
@@ -172,7 +173,7 @@ func (aws *AWS) Delete(cluster *clusterv1.Cluster, machine *clusterv1.Machine, c
 	}
 
 	//Make sure instance exists before attempting delete
-	exists, err := aws.Exists(cluster, machine, clientset)
+	exists, err := aws.Exists(ctx, cluster, machine, clientset)
 	if err != nil {
 		return err
 	}
@@ -198,7 +199,7 @@ func (aws *AWS) Delete(cluster *clusterv1.Cluster, machine *clusterv1.Machine, c
 }
 
 // Exists returns whether or not an instance is present in AWS.
-func (aws *AWS) Exists(cluster *clusterv1.Cluster, machine *clusterv1.Machine, clientset *kubernetes.Clientset) (bool, error) {
+func (aws *AWS) Exists(ctx context.Context, cluster *clusterv1.Cluster, machine *clusterv1.Machine, clientset *kubernetes.Clientset) (bool, error) {
 	// Fish out configs and create an ec2 client
 	machineSpec, err := utils.MachineProviderFromSpec(machine.Spec.ProviderSpec)
 	if err != nil {

--- a/pkg/cloud/talos/provisioners/azure/azure.go
+++ b/pkg/cloud/talos/provisioners/azure/azure.go
@@ -1,0 +1,415 @@
+package azure
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"log"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-03-01/compute"
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-04-01/network"
+	"github.com/Azure/go-autorest/autorest"
+	azuresdk "github.com/Azure/go-autorest/autorest/azure"
+	"github.com/Azure/go-autorest/autorest/azure/auth"
+	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/talos-systems/cluster-api-provider-talos/pkg/cloud/talos/utils"
+	"gopkg.in/yaml.v2"
+	"k8s.io/client-go/kubernetes"
+	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+)
+
+// Az represents a provider for Azure.
+type Az struct {
+}
+
+// ClusterInfo holds data about desired config in cluster object
+type ClusterInfo struct {
+	Location      string
+	ResourceGroup string
+	Instances     InstanceInfo
+}
+
+// InstanceInfo holds data about the instances we'll create
+type InstanceInfo struct {
+	Type    string
+	Image   string
+	Network string
+	Subnet  string
+	Disks   DiskInfo
+}
+
+// DiskInfo holds disk info data
+type DiskInfo struct {
+	Size int
+}
+
+// Session is an object representing session for subscription
+type Session struct {
+	SubscriptionID string
+	Authorizer     autorest.Authorizer
+}
+
+// NewAz returns an instance of the Azure provisioner
+func NewAz() (*Az, error) {
+	return &Az{}, nil
+}
+
+// Create creates an instance in Azure.
+func (azure *Az) Create(ctx context.Context, cluster *clusterv1.Cluster, machine *clusterv1.Machine, clientset *kubernetes.Clientset) error {
+	clusterSpec, err := utils.ClusterProviderFromSpec(cluster.Spec.ProviderSpec)
+	if err != nil {
+		return err
+	}
+
+	machineSpec, err := utils.MachineProviderFromSpec(machine.Spec.ProviderSpec)
+	if err != nil {
+		return err
+	}
+
+	azureConfig := &ClusterInfo{}
+	yaml.Unmarshal([]byte(machineSpec.Platform.Config), azureConfig)
+
+	// Dig out the subnet for our nic
+	subnet, err := getSubnetByName(ctx, azureConfig)
+	if err != nil {
+		return err
+	}
+
+	// Begin crafting the config for the nic
+	nicIPConfigProperties := &network.InterfaceIPConfigurationPropertiesFormat{
+		PrivateIPAllocationMethod: network.Dynamic,
+		Subnet:                    subnet,
+	}
+
+	// Find the public IP we want to use if necessary
+	if !strings.Contains(machine.ObjectMeta.Name, "worker") {
+		nameSlice := strings.Split(machine.ObjectMeta.Name, "-")
+		indexString := nameSlice[len(nameSlice)-1]
+		index, err := strconv.Atoi(indexString)
+		if err != nil {
+			return err
+		}
+		publicIP := clusterSpec.Masters.IPs[index]
+		publicIPObject, err := getPublicIPbyIP(ctx, publicIP, azureConfig.ResourceGroup)
+		if err != nil {
+			return err
+		}
+
+		// If we don't receive an IP object, the public IP wasn't found
+		// even though we're expecting it to be there. This logic may
+		// eventually change once we create IPs for the user.
+		if publicIPObject == nil {
+			return errors.New("expected public IP not found")
+		}
+		nicIPConfigProperties.PublicIPAddress = publicIPObject
+	}
+
+	// Create a network interface for our VM to use (with flip attached if necessary)
+	nic := network.Interface{
+		Name:     to.StringPtr(machine.ObjectMeta.Name + "-nic"),
+		Location: to.StringPtr(azureConfig.Location),
+		InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
+			IPConfigurations: &[]network.InterfaceIPConfiguration{
+				{
+					Name:                                     to.StringPtr(machine.ObjectMeta.Name + "-ip-config"),
+					InterfaceIPConfigurationPropertiesFormat: nicIPConfigProperties,
+				},
+			},
+		},
+	}
+	nicClient, err := nicclient()
+	if err != nil {
+		return err
+	}
+	nicfuture, err := nicClient.CreateOrUpdate(ctx, azureConfig.ResourceGroup, *nic.Name, nic)
+	if err != nil {
+		return err
+	}
+	err = nicfuture.WaitForCompletionRef(ctx, nicClient.Client)
+	if err != nil {
+		return err
+	}
+	nicObject, err := nicfuture.Result(*nicClient)
+	if err != nil {
+		return err
+	}
+
+	// Pull down userdata and b64 encode it
+	udConfigMap, err := utils.FetchConfigMap(cluster, machine, clientset)
+	if err != nil {
+		return err
+	}
+	ud := udConfigMap.Data["userdata"]
+	udb64 := base64.StdEncoding.EncodeToString([]byte(ud))
+
+	// Specify dummy val pass. We don't it anyways but it's required.
+	user := "talosuser"
+	password := utils.RandomString(15)
+
+	// Draft and create VM
+	vm := compute.VirtualMachine{
+		Location: to.StringPtr(azureConfig.Location),
+		VirtualMachineProperties: &compute.VirtualMachineProperties{
+			HardwareProfile: &compute.HardwareProfile{
+				VMSize: compute.VirtualMachineSizeTypes(azureConfig.Instances.Type),
+			},
+			StorageProfile: &compute.StorageProfile{
+				ImageReference: &compute.ImageReference{ID: to.StringPtr(azureConfig.Instances.Image)},
+				OsDisk: &compute.OSDisk{
+					OsType:       compute.Linux,
+					Name:         to.StringPtr(machine.ObjectMeta.Name + "-os-disk"),
+					CreateOption: compute.DiskCreateOptionTypesFromImage,
+					DiskSizeGB:   to.Int32Ptr(int32(azureConfig.Instances.Disks.Size)),
+				},
+			},
+			OsProfile: &compute.OSProfile{
+				ComputerName:  to.StringPtr(machine.ObjectMeta.Name),
+				AdminUsername: to.StringPtr(user),
+				AdminPassword: to.StringPtr(password),
+				CustomData:    to.StringPtr(udb64),
+			},
+			NetworkProfile: &compute.NetworkProfile{
+				NetworkInterfaces: &[]compute.NetworkInterfaceReference{
+					{
+						ID: nicObject.ID,
+						NetworkInterfaceReferenceProperties: &compute.NetworkInterfaceReferenceProperties{
+							Primary: to.BoolPtr(true),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	vmClient, err := vmclient()
+	if err != nil {
+		return err
+	}
+
+	_, err = vmClient.CreateOrUpdate(ctx, azureConfig.ResourceGroup, machine.ObjectMeta.Name, vm)
+	if err != nil {
+		return err
+	}
+
+	log.Println("[Azure] Instance created: " + machine.ObjectMeta.Name)
+
+	return nil
+}
+
+//Update updates a given Azure instance.
+func (azure *Az) Update(ctx context.Context, cluster *clusterv1.Cluster, machine *clusterv1.Machine, clientset *kubernetes.Clientset) error {
+	return nil
+}
+
+// Delete deletes a Azure instance.
+func (azure *Az) Delete(ctx context.Context, cluster *clusterv1.Cluster, machine *clusterv1.Machine, clientset *kubernetes.Clientset) error {
+	machineSpec, err := utils.MachineProviderFromSpec(machine.Spec.ProviderSpec)
+	if err != nil {
+		return err
+	}
+
+	azureConfig := &ClusterInfo{}
+	yaml.Unmarshal([]byte(machineSpec.Platform.Config), azureConfig)
+
+	// Cleanup VM
+	vmClient, err := vmclient()
+	if err != nil {
+		return err
+	}
+	vmfuture, err := vmClient.Delete(ctx, azureConfig.ResourceGroup, machine.ObjectMeta.Name)
+	if err != nil {
+		return err
+	}
+	err = vmfuture.WaitForCompletionRef(ctx, vmClient.Client)
+	if err != nil {
+		return err
+	}
+
+	// Cleanup os disk
+	disksClient, err := disksclient()
+	if err != nil {
+		return err
+	}
+	disksfuture, err := disksClient.Delete(ctx, azureConfig.ResourceGroup, machine.ObjectMeta.Name+"-os-disk")
+	if err != nil {
+		return err
+	}
+	err = disksfuture.WaitForCompletionRef(ctx, disksClient.Client)
+	if err != nil {
+		return err
+	}
+
+	// Cleanup nic
+	nicClient, err := nicclient()
+	if err != nil {
+		return err
+	}
+	nicfuture, err := nicClient.Delete(ctx, azureConfig.ResourceGroup, machine.ObjectMeta.Name+"-nic")
+	if err != nil {
+		return err
+	}
+	err = nicfuture.WaitForCompletionRef(ctx, nicClient.Client)
+	if err != nil {
+		return err
+	}
+
+	log.Println("[Azure] Instance deleted: " + machine.ObjectMeta.Name)
+
+	return nil
+}
+
+// Exists returns whether or not an instance is present in Azure.
+func (azure *Az) Exists(ctx context.Context, cluster *clusterv1.Cluster, machine *clusterv1.Machine, clientset *kubernetes.Clientset) (bool, error) {
+	machineSpec, err := utils.MachineProviderFromSpec(machine.Spec.ProviderSpec)
+	if err != nil {
+		return false, err
+	}
+
+	azureConfig := &ClusterInfo{}
+	yaml.Unmarshal([]byte(machineSpec.Platform.Config), azureConfig)
+
+	vmClient, err := vmclient()
+	if err != nil {
+		return true, err
+	}
+
+	// If there's an error from retrieving the VM by name, assume it doesn't exist
+	_, err = getVMByName(ctx, vmClient, azureConfig.ResourceGroup, machine.ObjectMeta.Name)
+	if err != nil {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+// getSubnetByName finds a given subnet (required for input along with network)
+func getSubnetByName(ctx context.Context, azureConfig *ClusterInfo) (*network.Subnet, error) {
+	client, err := subnetclient()
+	if err != nil {
+		return nil, err
+	}
+
+	subnet, err := client.Get(ctx, azureConfig.ResourceGroup, azureConfig.Instances.Network, azureConfig.Instances.Subnet, "")
+	if err != nil {
+		return nil, err
+	}
+
+	return &subnet, nil
+}
+
+// getPublicIPbyIP finds the public IP object from a list of all IP objects
+func getPublicIPbyIP(ctx context.Context, ipAddress string, resourceGroup string) (*network.PublicIPAddress, error) {
+	client, err := ipclient()
+	if err != nil {
+		return nil, err
+	}
+
+	//Dump all public IPs created and iterate to find our desired IP
+	list, err := client.ListComplete(ctx, resourceGroup)
+	if err != nil {
+		return nil, err
+	}
+	for list.NotDone() {
+		result := list.Value()
+		if *result.PublicIPAddressPropertiesFormat.IPAddress == ipAddress {
+			return &result, nil
+		}
+		err = list.NextWithContext(ctx)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// IP not found
+	return nil, nil
+}
+
+// getVMByName finds the VM given a machine name
+func getVMByName(ctx context.Context, vmClient *compute.VirtualMachinesClient, resourceGroup string, vmName string) (*compute.VirtualMachine, error) {
+	vm, err := vmClient.Get(ctx, resourceGroup, vmName, "")
+	if err != nil {
+		return nil, err
+	}
+
+	return &vm, nil
+}
+
+// fetchCreds creates a new authorizer and parses out the credentials file. Used by various clients for creation
+func fetchCreds() (autorest.Authorizer, map[string]interface{}, error) {
+	authorizer, err := auth.NewAuthorizerFromFile(azuresdk.PublicCloud.ResourceManagerEndpoint)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	credFile, err := ioutil.ReadFile(os.Getenv("AZURE_AUTH_LOCATION"))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	credMap := make(map[string]interface{})
+	err = json.Unmarshal(credFile, &credMap)
+	if err != nil {
+		return nil, nil, err
+	}
+	return authorizer, credMap, nil
+}
+
+// Creates client for use in disk ops
+func disksclient() (*compute.DisksClient, error) {
+	authorizer, credMap, err := fetchCreds()
+	if err != nil {
+		return nil, err
+	}
+	disksClient := compute.NewDisksClient(credMap["subscriptionId"].(string))
+	disksClient.Authorizer = authorizer
+	return &disksClient, nil
+}
+
+// Creates client for use in public IP ops
+func ipclient() (*network.PublicIPAddressesClient, error) {
+	authorizer, credMap, err := fetchCreds()
+	if err != nil {
+		return nil, err
+	}
+	ipClient := network.NewPublicIPAddressesClient(credMap["subscriptionId"].(string))
+	ipClient.Authorizer = authorizer
+	return &ipClient, nil
+}
+
+// Creates client for use in NIC ops
+func nicclient() (*network.InterfacesClient, error) {
+	authorizer, credMap, err := fetchCreds()
+	if err != nil {
+		return nil, err
+	}
+	nicClient := network.NewInterfacesClient(credMap["subscriptionId"].(string))
+	nicClient.Authorizer = authorizer
+	return &nicClient, nil
+}
+
+// Creates client for use in subnet ops
+func subnetclient() (*network.SubnetsClient, error) {
+	authorizer, credMap, err := fetchCreds()
+	if err != nil {
+		return nil, err
+	}
+	subnetClient := network.NewSubnetsClient(credMap["subscriptionId"].(string))
+	subnetClient.Authorizer = authorizer
+	return &subnetClient, nil
+}
+
+// Creates client for use in VM ops
+func vmclient() (*compute.VirtualMachinesClient, error) {
+	authorizer, credMap, err := fetchCreds()
+	if err != nil {
+		return nil, err
+	}
+	vmClient := compute.NewVirtualMachinesClient(credMap["subscriptionId"].(string))
+	vmClient.Authorizer = authorizer
+	return &vmClient, nil
+}

--- a/pkg/cloud/talos/provisioners/gce/gce.go
+++ b/pkg/cloud/talos/provisioners/gce/gce.go
@@ -47,7 +47,7 @@ func NewGCE() (*GCE, error) {
 }
 
 // Create creates an instance in GCE.
-func (gce *GCE) Create(cluster *clusterv1.Cluster, machine *clusterv1.Machine, clientset *kubernetes.Clientset) error {
+func (gce *GCE) Create(ctx context.Context, cluster *clusterv1.Cluster, machine *clusterv1.Machine, clientset *kubernetes.Clientset) error {
 
 	clusterSpec, err := utils.ClusterProviderFromSpec(cluster.Spec.ProviderSpec)
 	if err != nil {
@@ -129,16 +129,16 @@ func (gce *GCE) Create(cluster *clusterv1.Cluster, machine *clusterv1.Machine, c
 }
 
 //Update updates a given GCE instance.
-func (gce *GCE) Update(cluster *clusterv1.Cluster, machine *clusterv1.Machine, clientset *kubernetes.Clientset) error {
+func (gce *GCE) Update(ctx context.Context, cluster *clusterv1.Cluster, machine *clusterv1.Machine, clientset *kubernetes.Clientset) error {
 
 	return nil
 }
 
 // Delete deletes a GCE instance.
-func (gce *GCE) Delete(cluster *clusterv1.Cluster, machine *clusterv1.Machine, clientset *kubernetes.Clientset) error {
+func (gce *GCE) Delete(ctx context.Context, cluster *clusterv1.Cluster, machine *clusterv1.Machine, clientset *kubernetes.Clientset) error {
 
 	// If instance isn't found by name, assume we no longer need to delete
-	exists, err := gce.Exists(cluster, machine, clientset)
+	exists, err := gce.Exists(ctx, cluster, machine, clientset)
 	if err != nil {
 		return err
 	}
@@ -167,7 +167,7 @@ func (gce *GCE) Delete(cluster *clusterv1.Cluster, machine *clusterv1.Machine, c
 }
 
 // Exists returns whether or not an instance is present in GCE.
-func (gce *GCE) Exists(cluster *clusterv1.Cluster, machine *clusterv1.Machine, clientset *kubernetes.Clientset) (bool, error) {
+func (gce *GCE) Exists(ctx context.Context, cluster *clusterv1.Cluster, machine *clusterv1.Machine, clientset *kubernetes.Clientset) (bool, error) {
 	machineSpec, err := utils.MachineProviderFromSpec(machine.Spec.ProviderSpec)
 	if err != nil {
 		return false, err

--- a/pkg/cloud/talos/provisioners/packet/packet.go
+++ b/pkg/cloud/talos/provisioners/packet/packet.go
@@ -1,6 +1,7 @@
 package packet
 
 import (
+	"context"
 	"errors"
 	"log"
 	"strconv"
@@ -61,7 +62,7 @@ func NewPacket() (*Packet, error) {
 }
 
 // Create creates an instance in Packet.
-func (packet *Packet) Create(cluster *clusterv1.Cluster, machine *clusterv1.Machine, clientset *kubernetes.Clientset) error {
+func (packet *Packet) Create(ctx context.Context, cluster *clusterv1.Cluster, machine *clusterv1.Machine, clientset *kubernetes.Clientset) error {
 
 	clusterSpec, err := utils.ClusterProviderFromSpec(cluster.Spec.ProviderSpec)
 	if err != nil {
@@ -153,12 +154,12 @@ func (packet *Packet) Create(cluster *clusterv1.Cluster, machine *clusterv1.Mach
 }
 
 //Update updates a given Packet instance.
-func (packet *Packet) Update(cluster *clusterv1.Cluster, machine *clusterv1.Machine, clientset *kubernetes.Clientset) error {
+func (packet *Packet) Update(ctx context.Context, cluster *clusterv1.Cluster, machine *clusterv1.Machine, clientset *kubernetes.Clientset) error {
 	return nil
 }
 
 // Delete deletes a Packet instance.
-func (packet *Packet) Delete(cluster *clusterv1.Cluster, machine *clusterv1.Machine, clientset *kubernetes.Clientset) error {
+func (packet *Packet) Delete(ctx context.Context, cluster *clusterv1.Cluster, machine *clusterv1.Machine, clientset *kubernetes.Clientset) error {
 
 	dev, err := packet.fetchDevice(machine)
 	if err != nil {
@@ -175,7 +176,7 @@ func (packet *Packet) Delete(cluster *clusterv1.Cluster, machine *clusterv1.Mach
 }
 
 // Exists returns whether or not an instance is present in AWS.
-func (packet *Packet) Exists(cluster *clusterv1.Cluster, machine *clusterv1.Machine, clientset *kubernetes.Clientset) (bool, error) {
+func (packet *Packet) Exists(ctx context.Context, cluster *clusterv1.Cluster, machine *clusterv1.Machine, clientset *kubernetes.Clientset) (bool, error) {
 
 	dev, err := packet.fetchDevice(machine)
 	if err != nil {

--- a/pkg/cloud/talos/provisioners/provision.go
+++ b/pkg/cloud/talos/provisioners/provision.go
@@ -1,9 +1,11 @@
 package provisioners
 
 import (
+	"context"
 	"errors"
 
 	"github.com/talos-systems/cluster-api-provider-talos/pkg/cloud/talos/provisioners/aws"
+	"github.com/talos-systems/cluster-api-provider-talos/pkg/cloud/talos/provisioners/azure"
 	"github.com/talos-systems/cluster-api-provider-talos/pkg/cloud/talos/provisioners/gce"
 	"github.com/talos-systems/cluster-api-provider-talos/pkg/cloud/talos/provisioners/packet"
 	"k8s.io/client-go/kubernetes"
@@ -11,19 +13,21 @@ import (
 )
 
 type Provisioner interface {
-	Create(*clusterv1.Cluster, *clusterv1.Machine, *kubernetes.Clientset) error
-	Update(*clusterv1.Cluster, *clusterv1.Machine, *kubernetes.Clientset) error
+	Create(context.Context, *clusterv1.Cluster, *clusterv1.Machine, *kubernetes.Clientset) error
+	Update(context.Context, *clusterv1.Cluster, *clusterv1.Machine, *kubernetes.Clientset) error
 
-	Delete(*clusterv1.Cluster, *clusterv1.Machine, *kubernetes.Clientset) error
-	Exists(*clusterv1.Cluster, *clusterv1.Machine, *kubernetes.Clientset) (bool, error)
+	Delete(context.Context, *clusterv1.Cluster, *clusterv1.Machine, *kubernetes.Clientset) error
+	Exists(context.Context, *clusterv1.Cluster, *clusterv1.Machine, *kubernetes.Clientset) (bool, error)
 }
 
 func NewProvisioner(id string) (Provisioner, error) {
 	switch id {
-	case "gce":
-		return gce.NewGCE()
 	case "aws":
 		return aws.NewAWS()
+	case "azure":
+		return azure.NewAz()
+	case "gce":
+		return gce.NewGCE()
 	case "packet":
 		return packet.NewPacket()
 	}

--- a/pkg/cloud/talos/utils/utils.go
+++ b/pkg/cloud/talos/utils/utils.go
@@ -16,7 +16,7 @@ import (
 
 //RandomString simply returns a string of length n
 func RandomString(n int) string {
-	var letter = []rune("abcdefghijklmnopqrstuvwxy0123456789")
+	var letter = []rune("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxy0123456789")
 
 	b := make([]rune, n)
 	for i := range b {


### PR DESCRIPTION
This PR will add the ability to provision talos nodes on azure. The Azure SDK requires context all over the place, so I added it to the interface and to all provisioners as well. That way we'll have it in others if we want to make use of it.

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>