### PR TITLE
fix: ignore machine config regeneration on reconcile of clusters

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -571,7 +571,7 @@
   version = "v1.0.3"
 
 [[projects]]
-  digest = "1:c6fa5ae2153d7b7dfc826a0143e8905c56c953d32bab2819900b4b14542b9b9e"
+  digest = "1:b10dd21a2d572d35ac136c58f402b5391cb1b71fc9434a4be1a65418012e70f3"
   name = "github.com/talos-systems/talos"
   packages = [
     "internal/pkg/constants",
@@ -581,8 +581,8 @@
     "pkg/userdata/token",
   ]
   pruneopts = "T"
-  revision = "40ae00d90cf9b57a8d731d72992305bf5d6fd5f2"
-  version = "v0.2.0-alpha.2"
+  revision = "6fa7c1fcbd17761b3ea996662f18864acf9b3194"
+  version = "v0.2.0-alpha.3"
 
 [[projects]]
   digest = "1:b0115d3a61a91feb9163bd91ca59d51fd6d40e2ea081293273263699ecb0c3d3"

--- a/pkg/cloud/talos/actuators/cluster/actuator.go
+++ b/pkg/cloud/talos/actuators/cluster/actuator.go
@@ -19,6 +19,7 @@ package cluster
 import (
 	"context"
 	"errors"
+	"log"
 	"net"
 	"strconv"
 
@@ -63,6 +64,7 @@ func NewClusterActuator(mgr manager.Manager, params ClusterActuatorParams) (*Clu
 // Reconcile reconciles a cluster and is invoked by the Cluster Controller
 // TODO: This needs to be idempotent. Check if these certs and stuff already exist
 func (a *ClusterActuator) Reconcile(cluster *clusterv1.Cluster) error {
+	log.Printf("Reconciling cluster %v.", cluster.Name)
 
 	spec, err := utils.ClusterProviderFromSpec(cluster.Spec.ProviderSpec)
 	if err != nil {
@@ -178,8 +180,10 @@ func createConfigMap(clientset *kubernetes.Clientset, name string, data map[stri
 	}
 
 	_, err := clientset.CoreV1().ConfigMaps(ClusterAPIProviderTalosNamespace).Create(cm)
+	// Essentially no-op if CMs are already there
 	if k8serrors.IsAlreadyExists(err) {
-		_, err = clientset.CoreV1().ConfigMaps(ClusterAPIProviderTalosNamespace).Update(cm)
+		return nil
+		//_, err = clientset.CoreV1().ConfigMaps(ClusterAPIProviderTalosNamespace).Update(cm)
 	}
 
 	return err


### PR DESCRIPTION
This PR will fix a bug we were seeing where the second reconcile call
to the cluster object was overwriting the configmaps that contained
talosconfig and machine config. Also pulls in Talos v0.2.0-alpha.3

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>