### PR TITLE
feat: enable parallel deletion of azure resources

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -8,7 +8,8 @@ workspace:
 
 services:
   - name: docker
-    image: docker:dind
+    image: docker:19.03-dind
+    entrypoint: [dockerd]
     privileged: true
     command:
       - --dns=8.8.8.8

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -56,17 +56,19 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
+          - name: AZURE_AUTH_LOCATION
+            value: /.azure/service-account.json
           - name: GOOGLE_APPLICATION_CREDENTIALS
             value: /.gce/service-account.json
           - name: PACKET_AUTH_TOKEN
             value: "{{PACKET_AUTH_TOKEN}}"
         resources:
           limits:
-            cpu: 100m
-            memory: 30Mi
+            cpu: 1000m
+            memory: 1000Mi
           requests:
             cpu: 100m
-            memory: 20Mi
+            memory: 100Mi
         ports:
         - containerPort: 9876
           name: webhook-server
@@ -75,6 +77,8 @@ spec:
         - mountPath: /tmp/cert
           name: cert
           readOnly: true
+        - mountPath: /.azure
+          name: azure-credentials
         - name: gce-credentials
           mountPath: /.gce
         - name: aws-credentials
@@ -87,6 +91,9 @@ spec:
         secret:
           defaultMode: 420
           secretName: webhook-server-secret
+      - name: azure-credentials
+        secret:
+          secretName: azure-credentials
       - name: gce-credentials
         secret:
           secretName: gce-credentials


### PR DESCRIPTION
This PR will push the cleanup of nics and os disks into a background
goroutine in an effort to parallelize the cleanup of azure resources.

Also includes some minor changes around resource size of the controller
and fixing the docker race condition in drone.

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>