### PR TITLE
feat: create floating IPs for aws, gce, azure

### DIFF
--- a/config/samples/cluster-deployment/aws/kustomization.yaml
+++ b/config/samples/cluster-deployment/aws/kustomization.yaml
@@ -8,7 +8,7 @@ patchesJson6902:
       version: v1alpha1
       kind: Cluster
       name: talos-test-cluster
-    path: master-ips.yaml
+    path: platform-config-cluster.yaml
 
   ##Patch each master with gce config
   - target:
@@ -17,18 +17,18 @@ patchesJson6902:
       kind: Machine
       name: talos-test-cluster-master-0
     path: platform-config-masters.yaml
-  # - target:
-  #     group: cluster.k8s.io
-  #     version: v1alpha1
-  #     kind: Machine
-  #     name: talos-test-cluster-master-1
-  #   path: platform-config-masters.yaml
-  # - target:
-  #     group: cluster.k8s.io
-  #     version: v1alpha1
-  #     kind: Machine
-  #     name: talos-test-cluster-master-2
-  #   path: platform-config-masters.yaml
+  - target:
+      group: cluster.k8s.io
+      version: v1alpha1
+      kind: Machine
+      name: talos-test-cluster-master-1
+    path: platform-config-masters.yaml
+  - target:
+      group: cluster.k8s.io
+      version: v1alpha1
+      kind: Machine
+      name: talos-test-cluster-master-2
+    path: platform-config-masters.yaml
 
   ##Patch workers with gce config
   - target:

--- a/config/samples/cluster-deployment/aws/master-ips.yaml
+++ b/config/samples/cluster-deployment/aws/master-ips.yaml
@@ -1,3 +1,0 @@
-- op: replace
-  path: /spec/providerSpec/value/masters/ips
-  value: [x.x.x.x, y.y.y.y, z.z.z.z]

--- a/config/samples/cluster-deployment/aws/platform-config-cluster.yaml
+++ b/config/samples/cluster-deployment/aws/platform-config-cluster.yaml
@@ -1,0 +1,6 @@
+- op: replace
+  path: /spec/providerSpec/value/platform
+  value:
+    config: |-
+      region: "us-west-2"
+    type: aws

--- a/config/samples/cluster-deployment/azure/kustomization.yaml
+++ b/config/samples/cluster-deployment/azure/kustomization.yaml
@@ -8,7 +8,7 @@ patchesJson6902:
       version: v1alpha1
       kind: Cluster
       name: talos-test-cluster
-    path: master-ips.yaml
+    path: platform-config-cluster.yaml
 
   ##Patch each master with gce config
   - target:
@@ -17,18 +17,18 @@ patchesJson6902:
       kind: Machine
       name: talos-test-cluster-master-0
     path: platform-config-masters.yaml
-  # - target:
-  #     group: cluster.k8s.io
-  #     version: v1alpha1
-  #     kind: Machine
-  #     name: talos-test-cluster-master-1
-  #   path: platform-config-masters.yaml
-  # - target:
-  #     group: cluster.k8s.io
-  #     version: v1alpha1
-  #     kind: Machine
-  #     name: talos-test-cluster-master-2
-  #   path: platform-config-masters.yaml
+  - target:
+      group: cluster.k8s.io
+      version: v1alpha1
+      kind: Machine
+      name: talos-test-cluster-master-1
+    path: platform-config-masters.yaml
+  - target:
+      group: cluster.k8s.io
+      version: v1alpha1
+      kind: Machine
+      name: talos-test-cluster-master-2
+    path: platform-config-masters.yaml
 
   ##Patch workers with gce config
   - target:

--- a/config/samples/cluster-deployment/azure/master-ips.yaml
+++ b/config/samples/cluster-deployment/azure/master-ips.yaml
@@ -1,3 +1,0 @@
-- op: replace
-  path: /spec/providerSpec/value/masters/ips
-  value: [x.x.x.x, y.y.y.y, z.z.z.z]

--- a/config/samples/cluster-deployment/azure/platform-config-cluster.yaml
+++ b/config/samples/cluster-deployment/azure/platform-config-cluster.yaml
@@ -1,0 +1,7 @@
+- op: replace
+  path: /spec/providerSpec/value/platform
+  value:
+    config: |-
+      location: "centralus"
+      resourcegroup: "{{RESOURCE_GROUP}}"
+    type: azure

--- a/config/samples/cluster-deployment/base/cluster.yaml
+++ b/config/samples/cluster-deployment/base/cluster.yaml
@@ -14,5 +14,6 @@ spec:
     value:
       apiVersion: "talosproviderconfig/v1alpha1"
       kind: "TalosClusterProviderSpec"
-      masters:
-        ips: []
+      platform: {}
+      controlplane:
+        count: 3

--- a/config/samples/cluster-deployment/base/kustomization.yaml
+++ b/config/samples/cluster-deployment/base/kustomization.yaml
@@ -1,6 +1,6 @@
 resources:
   - cluster.yaml
   - master-0.yaml
-  # - master-1.yaml
-  # - master-2.yaml
+  - master-1.yaml
+  - master-2.yaml
   - worker-machines.yaml

--- a/config/samples/cluster-deployment/gce/kustomization.yaml
+++ b/config/samples/cluster-deployment/gce/kustomization.yaml
@@ -8,7 +8,7 @@ patchesJson6902:
       version: v1alpha1
       kind: Cluster
       name: talos-test-cluster
-    path: master-ips.yaml
+    path: platform-config-cluster.yaml
 
   ##Patch each master with gce config
   - target:
@@ -17,18 +17,18 @@ patchesJson6902:
       kind: Machine
       name: talos-test-cluster-master-0
     path: platform-config-masters.yaml
-  # - target:
-  #     group: cluster.k8s.io
-  #     version: v1alpha1
-  #     kind: Machine
-  #     name: talos-test-cluster-master-1
-  #   path: platform-config-masters.yaml
-  # - target:
-  #     group: cluster.k8s.io
-  #     version: v1alpha1
-  #     kind: Machine
-  #     name: talos-test-cluster-master-2
-  #   path: platform-config-masters.yaml
+  - target:
+      group: cluster.k8s.io
+      version: v1alpha1
+      kind: Machine
+      name: talos-test-cluster-master-1
+    path: platform-config-masters.yaml
+  - target:
+      group: cluster.k8s.io
+      version: v1alpha1
+      kind: Machine
+      name: talos-test-cluster-master-2
+    path: platform-config-masters.yaml
 
   ##Patch workers with gce config
   - target:

--- a/config/samples/cluster-deployment/gce/master-ips.yaml
+++ b/config/samples/cluster-deployment/gce/master-ips.yaml
@@ -1,3 +1,0 @@
-- op: replace
-  path: /spec/providerSpec/value/masters/ips
-  value: [x.x.x.x, y.y.y.y, z.z.z.z]

--- a/config/samples/cluster-deployment/gce/platform-config-cluster.yaml
+++ b/config/samples/cluster-deployment/gce/platform-config-cluster.yaml
@@ -1,0 +1,7 @@
+- op: replace
+  path: /spec/providerSpec/value/platform
+  value:
+    config: |-
+      region: "us-central1"
+      project: "{{PROJECT_NAME}}"
+    type: "gce"

--- a/config/samples/cluster-deployment/packet/kustomization.yaml
+++ b/config/samples/cluster-deployment/packet/kustomization.yaml
@@ -8,7 +8,7 @@ patchesJson6902:
       version: v1alpha1
       kind: Cluster
       name: talos-test-cluster
-    path: master-ips.yaml
+    path: platform-config-cluster.yaml
 
   ##Patch each master with packet config
   - target:
@@ -17,18 +17,18 @@ patchesJson6902:
       kind: Machine
       name: talos-test-cluster-master-0
     path: platform-config-masters.yaml
-  # - target:
-  #     group: cluster.k8s.io
-  #     version: v1alpha1
-  #     kind: Machine
-  #     name: talos-test-cluster-master-1
-  #   path: platform-config-masters.yaml
-  # - target:
-  #     group: cluster.k8s.io
-  #     version: v1alpha1
-  #     kind: Machine
-  #     name: talos-test-cluster-master-2
-  #   path: platform-config-masters.yaml
+  - target:
+      group: cluster.k8s.io
+      version: v1alpha1
+      kind: Machine
+      name: talos-test-cluster-master-1
+    path: platform-config-masters.yaml
+  - target:
+      group: cluster.k8s.io
+      version: v1alpha1
+      kind: Machine
+      name: talos-test-cluster-master-2
+    path: platform-config-masters.yaml
 
   ##Patch workers with packet config
   - target:

--- a/config/samples/cluster-deployment/packet/master-ips.yaml
+++ b/config/samples/cluster-deployment/packet/master-ips.yaml
@@ -1,3 +1,0 @@
-- op: replace
-  path: /spec/providerSpec/value/masters/ips
-  value: [x.x.x.x, y.y.y.y, z.z.z.z]

--- a/config/samples/cluster-deployment/packet/platform-config-cluster.yaml
+++ b/config/samples/cluster-deployment/packet/platform-config-cluster.yaml
@@ -1,0 +1,7 @@
+- op: replace
+  path: /spec/providerSpec/value/platform
+  value:
+    config: |-
+      projectid: {{PROJECT_ID}}
+      ipblock: {{IP_BLOCK}}
+    type: packet

--- a/docs/AWS.md
+++ b/docs/AWS.md
@@ -24,15 +24,12 @@ aws_secret_access_key = MhM...
 
 - Deploy the generated manifests with `kubectl create -f provider-components.yaml`
 
-
 #### Create new clusters
 
 There are sample kustomize templates in [config/samples/cluster-deployment/aws](../config/samples/cluster-deployment/aws) for deploying clusters. These will be our starting point.
 
-- In AWS, create an external IP address for each of your desired masters. Take note of these IPs for the next step.
+- Edit `platform-config-cluster.yaml`, `platform-config-master.yaml`, and `platform-config-workers.yaml` with your relevant data. 
 
-- Edit `master-ips.yaml`, `platform-config-master.yaml`, and `platform-config-workers.yaml` with your relevant data. 
-
-- From `config/samples/cluster-deployment/aws` issue `kustomize build | kubectl apply -f -`.
+- From `config/samples/cluster-deployment/aws` issue `kustomize build | kubectl apply -f -`. External IPs will get created and associated with Control Plane nodes automatically.
 
 - The talos config for your master can be found with `kubectl get cm -n cluster-api-provider-talos-system talos-test-cluster-master-0 -o jsonpath='{.data.talosconfig}'`.

--- a/docs/Azure.md
+++ b/docs/Azure.md
@@ -10,7 +10,6 @@ This guide assumes you have several prereqs created in Azure. These are:
 - Virtual network
 - Subnet in the virtual network
 - A security group for the subnet that allows ports 443, 50000, 50001
-- Public IPs for each master
 - Storage account for image upload
 - The Azure CLI configured and talking to your Azure account
 
@@ -43,8 +42,8 @@ In your cluster that you'll be using to create other clusters, you must prepare 
 
 There are sample kustomize templates in [config/samples/cluster-deployment/azure](../config/samples/cluster-deployment/azure) for deploying clusters. These will be our starting point.
 
-- Edit `master-ips.yaml`, `platform-config-master.yaml`, and `platform-config-workers.yaml` with your relevant data from the prereqs mentioned above. 
+- Edit `platform-config-cluster.yaml`, `platform-config-master.yaml`, and `platform-config-workers.yaml` with your relevant data from the prereqs mentioned above. 
 
-- From `config/samples/cluster-deployment/azure` issue `kustomize build | kubectl apply -f -`.
+- From `config/samples/cluster-deployment/azure` issue `kustomize build | kubectl apply -f -`. External IPs will get created and associated with Control Plane nodes automatically.
 
 - The talos config for your master can be found with `kubectl get cm -n cluster-api-provider-talos-system talos-test-cluster-master-0 -o jsonpath='{.data.talosconfig}'`.

--- a/docs/GCE.md
+++ b/docs/GCE.md
@@ -33,10 +33,8 @@ In your cluster that you'll be using to create other clusters, you must prepare 
 
 There are sample kustomize templates in [config/samples/cluster-deployment/gce](../config/samples/cluster-deployment/gce) for deploying clusters. These will be our starting point.
 
-- In GCE, create an external IP address for each of your desired masters. Take note of these IPs for the next step.
+- Edit `platform-config-cluster.yaml`, `platform-config-master.yaml`, and `platform-config-workers.yaml` with your relevant data. 
 
-- Edit `master-ips.yaml`, `platform-config-master.yaml`, and `platform-config-workers.yaml` with your relevant data. 
-
-- From `config/samples/cluster-deployment/gce` issue `kustomize build | kubectl apply -f -`.
+- From `config/samples/cluster-deployment/gce` issue `kustomize build | kubectl apply -f -`. External IPs will get created and associated with Control Plane nodes automatically.
 
 - The talos config for your master can be found with `kubectl get cm -n cluster-api-provider-talos-system talos-test-cluster-master-0 -o jsonpath='{.data.talosconfig}'`.

--- a/docs/Packet.md
+++ b/docs/Packet.md
@@ -27,9 +27,7 @@ There are sample kustomize templates in [config/samples/cluster-deployment/packe
 
 - In Packet, create a small subnet of elastic IPs for attaching to your masters. A /30 subnet should work well. Take note of the IPs in this subnet for the next step. General instructions for creating these [here](https://support.packet.com/kb/articles/elastic-ips).
 
-- Edit `master-ips.yaml` with the IPs created in the previous step.
-
-- Edit `platform-config-master.yaml`, and `platform-config-workers.yaml` with your relevant data. 
+- Edit `platform-config-cluster.yaml`, `platform-config-master.yaml`, and `platform-config-workers.yaml` with your relevant data, adding the IP block created above to `platform-config-cluster.yaml`.
 
 - From `config/samples/cluster-deployment/packet` issue `kustomize build | kubectl apply -f -`.
 

--- a/pkg/apis/talos/v1alpha1/talosclusterproviderspec_types.go
+++ b/pkg/apis/talos/v1alpha1/talosclusterproviderspec_types.go
@@ -20,14 +20,15 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-//TalosClusterMastersSpec is the spec that defines info about cluster masters
-type TalosClusterMastersSpec struct {
-	IPs []string `json:"ips,omitempty"`
+//TalosClusterControlPlaneSpec is the spec that defines info about cluster controlplane
+type TalosClusterControlPlaneSpec struct {
+	Count int `json:"count,omitempty"`
 }
 
-//TalosClusterWorkerSpec is the spec that defines info about cluster masters
-type TalosClusterWorkerSpec struct {
-	Name string `json:"name,omitempty"`
+//TalosClusterPlatformSpec defines info about platform configs
+type TalosClusterPlatformSpec struct {
+	Type   string `json:"type,omitempty"`
+	Config string `json:"config,omitempty"`
 }
 
 // TalosClusterProviderSpecStatus defines the observed state of TalosClusterProviderSpec
@@ -45,9 +46,9 @@ type TalosClusterProviderSpec struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Masters TalosClusterMastersSpec        `json:"masters,omitempty"`
-	Workers []TalosClusterWorkerSpec       `json:"workers,omitempty"`
-	Status  TalosClusterProviderSpecStatus `json:"status,omitempty"`
+	ControlPlane TalosClusterControlPlaneSpec   `json:"controlplane,omitempty"`
+	Platform     TalosClusterPlatformSpec       `json:"platform,omitempty"`
+	Status       TalosClusterProviderSpecStatus `json:"status,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/cloud/talos/actuators/machine/actuator.go
+++ b/pkg/cloud/talos/actuators/machine/actuator.go
@@ -61,7 +61,12 @@ func NewMachineActuator(mgr manager.Manager, params MachineActuatorParams) (*Mac
 func (a *MachineActuator) Create(ctx context.Context, cluster *clusterv1.Cluster, machine *clusterv1.Machine) error {
 	log.Printf("Creating machine %v for cluster %v.", machine.Name, cluster.Name)
 
-	provisioner, err := createProvisioner(machine)
+	spec, err := utils.MachineProviderFromSpec(machine.Spec.ProviderSpec)
+	if err != nil {
+		return err
+	}
+
+	provisioner, err := provisioners.NewProvisioner(spec.Platform.Type)
 	if err != nil {
 		return err
 	}
@@ -78,7 +83,12 @@ func (a *MachineActuator) Create(ctx context.Context, cluster *clusterv1.Cluster
 func (a *MachineActuator) Delete(ctx context.Context, cluster *clusterv1.Cluster, machine *clusterv1.Machine) error {
 	log.Printf("Deleting machine %v for cluster %v.", machine.Name, cluster.Name)
 
-	provisioner, err := createProvisioner(machine)
+	spec, err := utils.MachineProviderFromSpec(machine.Spec.ProviderSpec)
+	if err != nil {
+		return err
+	}
+
+	provisioner, err := provisioners.NewProvisioner(spec.Platform.Type)
 	if err != nil {
 		return err
 	}
@@ -95,7 +105,12 @@ func (a *MachineActuator) Delete(ctx context.Context, cluster *clusterv1.Cluster
 func (a *MachineActuator) Update(ctx context.Context, cluster *clusterv1.Cluster, machine *clusterv1.Machine) error {
 	log.Printf("Updating machine %v for cluster %v.", machine.Name, cluster.Name)
 
-	provisioner, err := createProvisioner(machine)
+	spec, err := utils.MachineProviderFromSpec(machine.Spec.ProviderSpec)
+	if err != nil {
+		return err
+	}
+
+	provisioner, err := provisioners.NewProvisioner(spec.Platform.Type)
 	if err != nil {
 		return err
 	}
@@ -111,7 +126,13 @@ func (a *MachineActuator) Update(ctx context.Context, cluster *clusterv1.Cluster
 // Exists tests for the existence of a machine and is invoked by the Machine Controller
 func (a *MachineActuator) Exists(ctx context.Context, cluster *clusterv1.Cluster, machine *clusterv1.Machine) (bool, error) {
 	log.Printf("Checking if machine %v for cluster %v exists.", machine.Name, cluster.Name)
-	provisioner, err := createProvisioner(machine)
+
+	spec, err := utils.MachineProviderFromSpec(machine.Spec.ProviderSpec)
+	if err != nil {
+		return true, err
+	}
+
+	provisioner, err := provisioners.NewProvisioner(spec.Platform.Type)
 	if err != nil {
 		return true, err
 	}
@@ -122,19 +143,4 @@ func (a *MachineActuator) Exists(ctx context.Context, cluster *clusterv1.Cluster
 	}
 
 	return exists, nil
-}
-
-func createProvisioner(machine *clusterv1.Machine) (provisioners.Provisioner, error) {
-
-	machineSpec, err := utils.MachineProviderFromSpec(machine.Spec.ProviderSpec)
-	if err != nil {
-		return nil, err
-	}
-
-	provisioner, err := provisioners.NewProvisioner(machineSpec.Platform.Type)
-	if err != nil {
-		return nil, err
-	}
-
-	return provisioner, nil
 }

--- a/pkg/cloud/talos/provisioners/provision.go
+++ b/pkg/cloud/talos/provisioners/provision.go
@@ -18,6 +18,9 @@ type Provisioner interface {
 
 	Delete(context.Context, *clusterv1.Cluster, *clusterv1.Machine, *kubernetes.Clientset) error
 	Exists(context.Context, *clusterv1.Cluster, *clusterv1.Machine, *kubernetes.Clientset) (bool, error)
+
+	AllocateExternalIPs(*clusterv1.Cluster, *kubernetes.Clientset) ([]string, error)
+	DeAllocateExternalIPs(*clusterv1.Cluster, *kubernetes.Clientset) error
 }
 
 func NewProvisioner(id string) (Provisioner, error) {


### PR DESCRIPTION
This PR will create floating IPs at the time of creation for each
provisioner. This will allow for more advance e2e, as well as an
enhanced user experience.

Still needs docs/kustomize cleanup, but basic functionality is working as expected.