### PR TITLE
feat: use talos v1 userdata generation for capi-created nodes

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -9,17 +9,19 @@ workspace:
 services:
   - name: docker
     image: docker:19.03-dind
-    entrypoint: [dockerd]
-    privileged: true
+    entrypoint:
+    - dockerd
     command:
-      - --dns=8.8.8.8
-      - --dns=8.8.4.4
-      - --mtu=1440
+    - --dns=8.8.8.8
+    - --dns=8.8.4.4
+    - --mtu=1440
+    - --log-level=error
+    privileged: true
     volumes:
-      - name: dockersock
-        path: /var/run
-      - name: manifests
-        path: /tmp/manifests
+    - name: dockersock
+      path: /var/run
+    - name: manifests
+      path: /tmp/manifests
 
 steps:
   - name: fetch

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -295,6 +295,22 @@
   version = "v1.9.5"
 
 [[projects]]
+  digest = "1:0ade334594e69404d80d9d323445d2297ff8161637f9b2d347cc6973d2d6f05b"
+  name = "github.com/hashicorp/errwrap"
+  packages = ["."]
+  pruneopts = "T"
+  revision = "8a6fb523712970c966eefc6b39ed2c5e74880354"
+  version = "v1.0.0"
+
+[[projects]]
+  digest = "1:f668349b83f7d779567c880550534addeca7ebadfdcf44b0b9c39be61864b4b7"
+  name = "github.com/hashicorp/go-multierror"
+  packages = ["."]
+  pruneopts = "T"
+  revision = "886a7fbe3eb1c874d46f623bfa70af45f425b3d1"
+  version = "v1.0.0"
+
+[[projects]]
   digest = "1:d15ee511aa0f56baacc1eb4c6b922fa1c03b38413b6be18166b996d82a0156ea"
   name = "github.com/hashicorp/golang-lru"
   packages = [
@@ -571,18 +587,19 @@
   version = "v1.0.3"
 
 [[projects]]
-  digest = "1:b10dd21a2d572d35ac136c58f402b5391cb1b71fc9434a4be1a65418012e70f3"
+  digest = "1:6ff0c4bae711885b116931b82ee6b4c0c3cf8a723e711425e9fbbd7c9413cb33"
   name = "github.com/talos-systems/talos"
   packages = [
-    "internal/pkg/constants",
-    "internal/pkg/kernel",
+    "pkg/constants",
     "pkg/crypto/x509",
-    "pkg/userdata/generate",
+    "pkg/net",
     "pkg/userdata/token",
+    "pkg/userdata/v1",
+    "pkg/userdata/v1/generate",
   ]
   pruneopts = "T"
-  revision = "6fa7c1fcbd17761b3ea996662f18864acf9b3194"
-  version = "v0.2.0-alpha.3"
+  revision = "83b978c98315d70a2fbbf21a26aa9bd725163a8b"
+  version = "v0.2.0-alpha.7"
 
 [[projects]]
   digest = "1:b0115d3a61a91feb9163bd91ca59d51fd6d40e2ea081293273263699ecb0c3d3"
@@ -772,6 +789,17 @@
   ]
   pruneopts = "T"
   revision = "128ec6dfca091cc7d4fe6d18d97911f37c95a590"
+
+[[projects]]
+  branch = "master"
+  digest = "1:7b5ce208ea2ca1f96322e6a5b616839fe49ea798648a013039f300475a1aadfc"
+  name = "golang.org/x/xerrors"
+  packages = [
+    ".",
+    "internal",
+  ]
+  pruneopts = "T"
+  revision = "a985d3407aa71f30cf86696ee0a2f409709f22e1"
 
 [[projects]]
   digest = "1:768a46371da6dd8f18fa03468cfb208ff9b2d58950da9a72b8cdb49f9c165a44"
@@ -1290,7 +1318,7 @@
     "github.com/emicklei/go-restful",
     "github.com/onsi/gomega",
     "github.com/packethost/packngo",
-    "github.com/talos-systems/talos/pkg/userdata/generate",
+    "github.com/talos-systems/talos/pkg/userdata/v1/generate",
     "golang.org/x/net/context",
     "google.golang.org/api/compute/v1",
     "google.golang.org/api/option",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -27,6 +27,10 @@ required = [
   name="sigs.k8s.io/cluster-api"
   version="0.1.7"
 
+[[constraint]]
+  name="github.com/talos-systems/talos"
+  version="0.2.0-alpha.7"
+
 # STANZAS BELOW ARE GENERATED AND MAY BE WRITTEN - DO NOT MODIFY BELOW THIS LINE.
 
 [[constraint]]

--- a/pkg/cloud/talos/actuators/cluster/actuator.go
+++ b/pkg/cloud/talos/actuators/cluster/actuator.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/talos-systems/cluster-api-provider-talos/pkg/cloud/talos/provisioners"
 	"github.com/talos-systems/cluster-api-provider-talos/pkg/cloud/talos/utils"
-	"github.com/talos-systems/talos/pkg/userdata/generate"
+	"github.com/talos-systems/talos/pkg/userdata/v1/generate"
 	v1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -157,7 +157,8 @@ func createMasterConfigMaps(cluster *clusterv1.Cluster, clientset *kubernetes.Cl
 
 	for i := 1; i < len(input.MasterIPs); i++ {
 		input.IP = net.ParseIP(input.MasterIPs[i])
-		input.Index = i - 1
+		input.Index = i
+
 		controlPlaneData, err := generate.Userdata(generate.TypeControlPlane, input)
 		if err != nil {
 			return err


### PR DESCRIPTION
Moves to using the master branch of Talos, which contains the v1 machine config code.

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>