### PR TITLE
fix: check if IP response is nil

### DIFF
--- a/pkg/cloud/talos/provisioners/aws/aws.go
+++ b/pkg/cloud/talos/provisioners/aws/aws.go
@@ -77,7 +77,7 @@ func (aws *AWS) Create(ctx context.Context, cluster *clusterv1.Cluster, machine 
 		if err != nil {
 			return err
 		}
-		if address.PublicIp == nil {
+		if address == nil {
 			return errors.New("IP not ready")
 		}
 		natIP = *address.PublicIp


### PR DESCRIPTION
This causes a panic if the response from AWS does not include the public
IP.