### PR TITLE
feat: generate v1alpha1 node confgs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/aws/aws-sdk-go v1.20.21
 	github.com/onsi/gomega v1.5.0
 	github.com/packethost/packngo v0.0.0-20190507131943-1343be729ca2
-	github.com/talos-systems/talos v0.2.0-alpha.7
+	github.com/talos-systems/talos v0.2.0-alpha.7.0.20190909170349-aed8c067307f
 	golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7
 	google.golang.org/api v0.7.0
 	gopkg.in/yaml.v2 v2.2.2

--- a/go.sum
+++ b/go.sum
@@ -718,8 +718,8 @@ github.com/stretchr/testify v1.3.1-0.20190311161405-34c6fa2dc709 h1:Ko2LQMrRU+Oy
 github.com/stretchr/testify v1.3.1-0.20190311161405-34c6fa2dc709/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/syndtr/gocapability v0.0.0-20160928074757-e7cb7fa329f4/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20180223013746-33e07d32887e/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
-github.com/talos-systems/talos v0.2.0-alpha.7 h1:P3qeo31zA9yfegv/VFqGnC9rcmtyuvskEaaBTY9Cr9Q=
-github.com/talos-systems/talos v0.2.0-alpha.7/go.mod h1:38lTu2MOXOr4mgTV7TQuIQuHIjnJ78OiW42knzdA8S4=
+github.com/talos-systems/talos v0.2.0-alpha.7.0.20190909170349-aed8c067307f h1:j8S/ypnZCIYs7sqrvYWyTj6TBzu19GGbxJdgp3LJ6Ks=
+github.com/talos-systems/talos v0.2.0-alpha.7.0.20190909170349-aed8c067307f/go.mod h1:xfvP7PjzD86jdQuRnF8Jx6j6puiKY6VPWx0f1sCAx2o=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
 github.com/thecodeteam/goscaleio v0.1.0/go.mod h1:68sdkZAsK8bvEwBlbQnlLS+xU+hvLYM/iQ8KXej1AwM=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/pkg/cloud/talos/actuators/cluster/actuator.go
+++ b/pkg/cloud/talos/actuators/cluster/actuator.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/talos-systems/cluster-api-provider-talos/pkg/cloud/talos/provisioners"
 	"github.com/talos-systems/cluster-api-provider-talos/pkg/cloud/talos/utils"
-	"github.com/talos-systems/talos/pkg/userdata/v1/generate"
+	"github.com/talos-systems/talos/pkg/userdata/v1alpha1/generate"
 	v1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"


### PR DESCRIPTION
This PR pulls in the latest talos code that will generate node configs
of the type v1alpha1 instead of v1.

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>